### PR TITLE
fix: correct Systeme.io fields/tags format in waitlist API (#47)

### DIFF
--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -36,10 +36,12 @@ export async function POST(request: NextRequest) {
       },
       body: JSON.stringify({
         email,
-        fields: {
-          first_name: trimmedFirstName,
-        },
-        tags: ['course-waitlist'],
+        fields: [
+          { slug: 'first_name', value: trimmedFirstName },
+        ],
+        tags: [
+          { name: 'course-waitlist' },
+        ],
       }),
     })
 


### PR DESCRIPTION
Closes #47

Changes:
- `fields` now sent as `[{slug, value}]` array instead of `{key: value}` object
- `tags` now sent as `[{name}]` array instead of `["string"]`

Verified correct format via direct API testing against Systeme.io.